### PR TITLE
build: bump superproject on changes to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Update superproject
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  bump-commit:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # TODO, build + test + reports, need to know how and what we're building and testing and reporting...
+
+      - name: Bump superproject commits
+        if: github.ref == 'refs/heads/master' # here if we run this CI for PRs in the future
+        run: |
+          mkdir superproject
+          cd superproject
+          git clone https://x-access-token:${{ secrets.BUMP_TOKEN }}@github.com/aeiouxx/nivlalulu .
+          ls -lha
+          git submodule update --init --remote frontend
+          cd frontend
+          git checkout $GITHUB_SHA
+          cd ..
+          git add frontend
+          git commit -m "Update commit version [skip ci]"
+          git push origin master

--- a/.github/workflows/pr-cache-close.yml
+++ b/.github/workflows/pr-cache-close.yml
@@ -1,0 +1,29 @@
+name: Delete cache for closed PRs
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete_cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge


### PR DESCRIPTION
New workflows:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R36): Added a workflow to update the superproject on every push to the master branch.
* [`.github/workflows/pr-cache-close.yml`](diffhunk://#diff-b478465f2e46d40a894fa816660e493430f64738379584987a41f4fb33919571R1-R29): Added a workflow to delete cache entries for closed pull requests.